### PR TITLE
fix: add index signature to PublicEndpoints

### DIFF
--- a/src/__fixtures__/class-return-type.d.ts
+++ b/src/__fixtures__/class-return-type.d.ts
@@ -4,7 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
-            [key: string]: (...args: unknown[])=>unknown;
+            [key: string]: (...args: any[])=>any;
             classReturnFunc(): Return;
         }
 

--- a/src/__fixtures__/class-return-type.d.ts
+++ b/src/__fixtures__/class-return-type.d.ts
@@ -4,6 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
+            [key: string]: (...args: unknown[])=>unknown;
             classReturnFunc(): Return;
         }
 

--- a/src/__fixtures__/interface-parameters-public-endpoints.d.ts
+++ b/src/__fixtures__/interface-parameters-public-endpoints.d.ts
@@ -4,7 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
-            [key: string]: (...args: unknown[])=>unknown;
+            [key: string]: (...args: any[])=>any;
             interfaceParamsFunc(params: IParams): void;
         }
 

--- a/src/__fixtures__/interface-parameters-public-endpoints.d.ts
+++ b/src/__fixtures__/interface-parameters-public-endpoints.d.ts
@@ -4,6 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
+            [key: string]: (...args: unknown[])=>unknown;
             interfaceParamsFunc(params: IParams): void;
         }
 

--- a/src/__fixtures__/interface-return-type.d.ts
+++ b/src/__fixtures__/interface-return-type.d.ts
@@ -4,7 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
-            [key: string]: (...args: unknown[])=>unknown;
+            [key: string]: (...args: any[])=>any;
             interfaceReturnFunc(): IReturn;
         }
 

--- a/src/__fixtures__/interface-return-type.d.ts
+++ b/src/__fixtures__/interface-return-type.d.ts
@@ -4,6 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
+            [key: string]: (...args: unknown[])=>unknown;
             interfaceReturnFunc(): IReturn;
         }
 

--- a/src/__fixtures__/object-return-type.d.ts
+++ b/src/__fixtures__/object-return-type.d.ts
@@ -4,7 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
-            [key: string]: (...args: unknown[])=>unknown;
+            [key: string]: (...args: any[])=>any;
             objectReturnFunc(): {
                 attr1: string;
                 attr2: number;

--- a/src/__fixtures__/object-return-type.d.ts
+++ b/src/__fixtures__/object-return-type.d.ts
@@ -4,6 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
+            [key: string]: (...args: unknown[])=>unknown;
             objectReturnFunc(): {
                 attr1: string;
                 attr2: number;

--- a/src/__fixtures__/primitive-return-type.d.ts
+++ b/src/__fixtures__/primitive-return-type.d.ts
@@ -4,7 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
-            [key: string]: (...args: unknown[])=>unknown;
+            [key: string]: (...args: any[])=>any;
             returnNumber(): number;
             returnString(): string;
             returnBoolean(): boolean;

--- a/src/__fixtures__/primitive-return-type.d.ts
+++ b/src/__fixtures__/primitive-return-type.d.ts
@@ -4,6 +4,7 @@ declare namespace google {
      */
     namespace script {
         interface PublicEndpoints {
+            [key: string]: (...args: unknown[])=>unknown;
             returnNumber(): number;
             returnString(): string;
             returnBoolean(): boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,22 @@ const generateIRunDts = (methods: dom.ObjectTypeMember[]) => {
 
 const generatePublicEndpointsDts = (methods: dom.ObjectTypeMember[]) => {
   const publicEndpoints = dom.create.interface('PublicEndpoints');
+  publicEndpoints.members.push(
+    dom.create.indexSignature(
+      "key",
+      "string",
+      dom.create.functionType(
+        [
+          dom.create.parameter(
+            "args",
+            dom.create.array("any"),
+            dom.ParameterFlags.Rest
+          ),
+        ],
+        "any"
+      )
+    )
+  );
   publicEndpoints.members.push(...methods);
   return publicEndpoints;
 }


### PR DESCRIPTION
Add an index signature to `PublicEndpoints` interface to match `FunctionMap` in gas-client.

closes #173