### PR TITLE
ci: Fix run-on to use matrix configuration

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:


### PR DESCRIPTION
### About
Update the configuration for CI workflow.
Fix run-on to use `matrix.os`. I'm sorry for missing necessary update at #209.